### PR TITLE
Add support for layer-specific perturbations and save intermediate Tyche values

### DIFF
--- a/src/tyche/estimator.py
+++ b/src/tyche/estimator.py
@@ -70,7 +70,6 @@ class VolumeConfig:
     adam_order: int = 2  # 1 for exp_avg, 2 for exp_avg_sq
 
     last_token_only: bool = False
-    # perturbation_mask: Optional[torch.Tensor] = None
     filter_str: Optional[str] = None
 
 
@@ -143,7 +142,6 @@ class VolumeEstimator(ABC):
             allow_unconverged=self.config.allow_unconverged,
             init_mult=self.config.init_mult,
             rtol=self.config.rtol
-            # perturbation_mask=self.config.perturbation_mask
 
         )
     
@@ -177,8 +175,8 @@ class CausalLMEstimator(VolumeEstimator):
             self.config.text_key = "text"
             
     def setup_model(self):
-        # self.latest_original_logits = []
-        # self.latest_perturbed_logits = []
+        self.latest_original_logits = []
+        self.latest_perturbed_logits = []
         print(f"CUDA Allocated: {torch.cuda.memory_allocated() / 1e9:.2f} GB")
 
 
@@ -237,7 +235,7 @@ class CausalLMEstimator(VolumeEstimator):
 
         # logits_p = self.apply_fn(self.params, self.val_data)
 
-        self.config.data_batch_size = min(16, self.val_data.shape[0])
+        self.config.data_batch_size = min(8, self.val_data.shape[0])
 
         logits_list = []
         for i in range(0, self.val_data.shape[0], self.config.data_batch_size):
@@ -249,21 +247,17 @@ class CausalLMEstimator(VolumeEstimator):
 
 
 
-        # self.latest_original_logits = logits_p.detach().cpu()
-
         if self.config.cache_mode:
             self.probs_p = torch.nn.functional.softmax(logits_p, dim=-1)
         else:
             self.probs_p = None
 
-        # logits_p_list = []  # <-- Add this line
         if self.config.cache_mode:
             # Process sequences data_batch_size at a time and store probs on CPU
             probs_p_list = []
             for i in range(0, self.val_data.shape[0], self.config.data_batch_size):
                 seqs = self.val_data[i:i+self.config.data_batch_size]
                 logits = self.apply_fn(self.params, seqs)
-                # logits_p_list.append(logits.to("cpu") if self.config.cache_mode == "cpu" else logits)
                 probs = torch.nn.functional.softmax(logits, dim=-1)
                 if self.config.cache_mode == "cpu":
                     probs_p_list.append(probs.to("cpu"))
@@ -277,9 +271,6 @@ class CausalLMEstimator(VolumeEstimator):
             self.probs_p = None
         
         def kl_fn(a, b, mults=None):
-            # For capturing final logits (you'll need to add flags to indicate when to save them)
-            final_logits_original = []
-            final_logits_perturbed = []
             def compute_multiplier(b, mults, i):
                 if mults is None:
                     return b
@@ -332,24 +323,10 @@ class CausalLMEstimator(VolumeEstimator):
                 else:
                     raise ValueError(f"Invalid cache mode: {self.config.cache_mode}")
                 
-
                 # Always store the latest logits
-                # self.latest_original_logits.append(logits_p.detach().cpu())
-                # self.latest_perturbed_logits.append(logits_q.detach().cpu())
-                # self.latest_perturbed_logits = [logits_q.detach().cpu()]
+                self.latest_perturbed_logits.append(logits_q.detach().cpu())
                 print(f"CUDA Allocated: {torch.cuda.memory_allocated() / 1e9:.2f} GB")
 
-
-                # del logits_q
-                # gc.collect()
-                # torch.cuda.empty_cache()
-
-
-                # print("=== Debugging KL divergence shapes ===")
-                # print(f"logprobs_q shape: {logprobs_q.shape}")
-                # print(f"probs_p_seq shape: {probs_p_seq.shape}")
-                # print(f"logprobs_q vocab size: {logprobs_q.shape[-1]}")
-                # print(f"probs_p_seq vocab size: {probs_p_seq.shape[-1]}")
                 kl_seq = torch.nn.functional.kl_div(logprobs_q, probs_p_seq, reduction="none").sum(dim=-1)
                 mask = seqs != self.tokenizer.pad_token_id
                 kl_seq_masked = kl_seq[mask]
@@ -495,7 +472,7 @@ class ConvNextEstimator(VolumeEstimator):
         self.apply_fn = apply_fn
         
         logits_p = self.apply_fn(self.params, self.val_data)
-        # self.latest_original_logits = logits_p.detach().cpu()
+        self.latest_original_logits = logits_p.detach().cpu()
         probs_p = torch.nn.functional.softmax(logits_p, dim=-1)
         
         def kl_fn(a, b, mults=None):

--- a/src/tyche/estimator.py
+++ b/src/tyche/estimator.py
@@ -18,7 +18,10 @@ from .convnext import (
     load_convnext_adam_vectors
 )
 from .vectors import ImplicitVector, ImplicitParamVector, ImplicitRandomVector
-print("hello")
+import os
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+
 @dataclass
 class VolumeConfig:
     # Common parameters
@@ -67,6 +70,9 @@ class VolumeConfig:
     adam_order: int = 2  # 1 for exp_avg, 2 for exp_avg_sq
 
     last_token_only: bool = False
+    # perturbation_mask: Optional[torch.Tensor] = None
+    filter_str: Optional[str] = None
+
 
 class VolumeEstimator(ABC):
     def __init__(self, config: VolumeConfig):
@@ -136,7 +142,9 @@ class VolumeEstimator(ABC):
             iters=self.config.iters,
             allow_unconverged=self.config.allow_unconverged,
             init_mult=self.config.init_mult,
-            rtol=self.config.rtol,
+            rtol=self.config.rtol
+            # perturbation_mask=self.config.perturbation_mask
+
         )
     
     @classmethod
@@ -146,7 +154,7 @@ class VolumeEstimator(ABC):
         elif config.model_type == "convnext":
             return ConvNextEstimator(config)
         elif config.model_type == "mlp":
-            raise NotImplementedError("MLP requires JAX, see branch `jax-hybrid`")
+            raise NotImplementedError("MLP requires JAX, see branch jax-hybrid")
         elif config.model_type == "causal":
             assert config.model is not None, "model must be provided for causal models"
             assert config.tokenizer is not None, "tokenizer must be provided for causal models"
@@ -169,8 +177,10 @@ class CausalLMEstimator(VolumeEstimator):
             self.config.text_key = "text"
             
     def setup_model(self):
-        self.latest_original_logits = []
-        self.latest_perturbed_logits = []
+        # self.latest_original_logits = []
+        # self.latest_perturbed_logits = []
+        print(f"CUDA Allocated: {torch.cuda.memory_allocated() / 1e9:.2f} GB")
+
 
         self.model = self.config.model
         self.tokenizer = self.config.tokenizer
@@ -180,7 +190,13 @@ class CausalLMEstimator(VolumeEstimator):
         self.model.to("cuda")
 
         if self.config.implicit_vectors:
-            self.params = ImplicitParamVector(self.model, self.config.block_size)
+            # self.params = ImplicitParamVector(self.model, self.config.block_size)
+            self.params = ImplicitParamVector(
+                self.model,
+                block_size=self.config.block_size,
+                filter_str=self.config.filter_str
+            )
+
         else:
             self.params = torch.nn.utils.parameters_to_vector(self.model.parameters()).detach()
 
@@ -211,8 +227,29 @@ class CausalLMEstimator(VolumeEstimator):
         tokens = tokens[:self.config.val_size]
         print(f"{tokens.shape=}")
         self.val_data = tokens.to("cuda")
-        logits_p = self.apply_fn(self.params, self.val_data)
-        self.latest_original_logits = logits_p.detach().cpu()
+
+        import gc
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        print(f"Memory allocated: {torch.cuda.memory_allocated() / 1e9:.2f} GB")
+        print(f"Memory reserved: {torch.cuda.memory_reserved() / 1e9:.2f} GB")
+
+        # logits_p = self.apply_fn(self.params, self.val_data)
+
+        self.config.data_batch_size = min(16, self.val_data.shape[0])
+
+        logits_list = []
+        for i in range(0, self.val_data.shape[0], self.config.data_batch_size):
+            batch = self.val_data[i:i + self.config.data_batch_size]
+            with torch.no_grad():
+                logits = self.apply_fn(self.params, batch)
+                logits_list.append(logits)
+        logits_p = torch.cat(logits_list, dim=0)
+
+
+
+        # self.latest_original_logits = logits_p.detach().cpu()
 
         if self.config.cache_mode:
             self.probs_p = torch.nn.functional.softmax(logits_p, dim=-1)
@@ -235,10 +272,6 @@ class CausalLMEstimator(VolumeEstimator):
                 else:
                     raise ValueError(f"Invalid cache mode: {self.config.cache_mode}")
                 
-            # self.probs_p = torch.cat(probs_p_list, dim=0)
-            # self.latest_original_logits = torch.cat(logits_p_list, dim=0)
-            # if self.config.cache_mode:
-            #     self.logits_p = torch.cat(logits_p_list, dim=0)  # Raw unperturbed logits (same shape as val_data)
 
         else:
             self.probs_p = None
@@ -302,7 +335,16 @@ class CausalLMEstimator(VolumeEstimator):
 
                 # Always store the latest logits
                 # self.latest_original_logits.append(logits_p.detach().cpu())
-                self.latest_perturbed_logits.append(logits_q.detach().cpu())
+                # self.latest_perturbed_logits.append(logits_q.detach().cpu())
+                # self.latest_perturbed_logits = [logits_q.detach().cpu()]
+                print(f"CUDA Allocated: {torch.cuda.memory_allocated() / 1e9:.2f} GB")
+
+
+                # del logits_q
+                # gc.collect()
+                # torch.cuda.empty_cache()
+
+
                 # print("=== Debugging KL divergence shapes ===")
                 # print(f"logprobs_q shape: {logprobs_q.shape}")
                 # print(f"probs_p_seq shape: {probs_p_seq.shape}")

--- a/src/tyche/estimator.py
+++ b/src/tyche/estimator.py
@@ -18,7 +18,7 @@ from .convnext import (
     load_convnext_adam_vectors
 )
 from .vectors import ImplicitVector, ImplicitParamVector, ImplicitRandomVector
-
+print("hello")
 @dataclass
 class VolumeConfig:
     # Common parameters
@@ -157,6 +157,7 @@ class VolumeEstimator(ABC):
 
 
 class CausalLMEstimator(VolumeEstimator):
+    
     def set_defaults(self):
         if self.config.model_batch_size is None:
             self.config.model_batch_size = 1
@@ -168,6 +169,9 @@ class CausalLMEstimator(VolumeEstimator):
             self.config.text_key = "text"
             
     def setup_model(self):
+        self.latest_original_logits = []
+        self.latest_perturbed_logits = []
+
         self.model = self.config.model
         self.tokenizer = self.config.tokenizer
         self.dataset = self.config.dataset
@@ -207,12 +211,22 @@ class CausalLMEstimator(VolumeEstimator):
         tokens = tokens[:self.config.val_size]
         print(f"{tokens.shape=}")
         self.val_data = tokens.to("cuda")
+        logits_p = self.apply_fn(self.params, self.val_data)
+        self.latest_original_logits = logits_p.detach().cpu()
+
+        if self.config.cache_mode:
+            self.probs_p = torch.nn.functional.softmax(logits_p, dim=-1)
+        else:
+            self.probs_p = None
+
+        # logits_p_list = []  # <-- Add this line
         if self.config.cache_mode:
             # Process sequences data_batch_size at a time and store probs on CPU
             probs_p_list = []
             for i in range(0, self.val_data.shape[0], self.config.data_batch_size):
                 seqs = self.val_data[i:i+self.config.data_batch_size]
                 logits = self.apply_fn(self.params, seqs)
+                # logits_p_list.append(logits.to("cpu") if self.config.cache_mode == "cpu" else logits)
                 probs = torch.nn.functional.softmax(logits, dim=-1)
                 if self.config.cache_mode == "cpu":
                     probs_p_list.append(probs.to("cpu"))
@@ -221,11 +235,18 @@ class CausalLMEstimator(VolumeEstimator):
                 else:
                     raise ValueError(f"Invalid cache mode: {self.config.cache_mode}")
                 
-            self.probs_p = torch.cat(probs_p_list, dim=0)
+            # self.probs_p = torch.cat(probs_p_list, dim=0)
+            # self.latest_original_logits = torch.cat(logits_p_list, dim=0)
+            # if self.config.cache_mode:
+            #     self.logits_p = torch.cat(logits_p_list, dim=0)  # Raw unperturbed logits (same shape as val_data)
+
         else:
             self.probs_p = None
         
         def kl_fn(a, b, mults=None):
+            # For capturing final logits (you'll need to add flags to indicate when to save them)
+            final_logits_original = []
+            final_logits_perturbed = []
             def compute_multiplier(b, mults, i):
                 if mults is None:
                     return b
@@ -278,6 +299,15 @@ class CausalLMEstimator(VolumeEstimator):
                 else:
                     raise ValueError(f"Invalid cache mode: {self.config.cache_mode}")
                 
+
+                # Always store the latest logits
+                # self.latest_original_logits.append(logits_p.detach().cpu())
+                self.latest_perturbed_logits.append(logits_q.detach().cpu())
+                # print("=== Debugging KL divergence shapes ===")
+                # print(f"logprobs_q shape: {logprobs_q.shape}")
+                # print(f"probs_p_seq shape: {probs_p_seq.shape}")
+                # print(f"logprobs_q vocab size: {logprobs_q.shape[-1]}")
+                # print(f"probs_p_seq vocab size: {probs_p_seq.shape[-1]}")
                 kl_seq = torch.nn.functional.kl_div(logprobs_q, probs_p_seq, reduction="none").sum(dim=-1)
                 mask = seqs != self.tokenizer.pad_token_id
                 kl_seq_masked = kl_seq[mask]
@@ -423,6 +453,7 @@ class ConvNextEstimator(VolumeEstimator):
         self.apply_fn = apply_fn
         
         logits_p = self.apply_fn(self.params, self.val_data)
+        # self.latest_original_logits = logits_p.detach().cpu()
         probs_p = torch.nn.functional.softmax(logits_p, dim=-1)
         
         def kl_fn(a, b, mults=None):

--- a/src/tyche/vectors.py
+++ b/src/tyche/vectors.py
@@ -30,16 +30,32 @@ class ImplicitVector(ABC):
         """Compute matrix product with another implicit vector."""
         return self.dot(other)
 
+
 class ImplicitParamVector(ImplicitVector):
-    def __init__(self, module: torch.nn.Module, block_size: int):
+    def __init__(self, module: torch.nn.Module, block_size: int, filter_str: str = None):
         super().__init__(block_size, module.device)
         self.module = module
-    
+        self.filter_str = filter_str  # e.g., "layers.15"
+
     def blocks(self) -> Iterator[torch.Tensor]:
-        for param in self.module.parameters():
+        for name, param in self.module.named_parameters():
+            if self.filter_str is not None and self.filter_str not in name:
+                continue
             flat_param = param.view(-1)
             for i in range(0, flat_param.numel(), self.block_size):
                 yield flat_param[i:i + self.block_size]
+
+
+# class ImplicitParamVector(ImplicitVector):
+#     def __init__(self, module: torch.nn.Module, block_size: int):
+#         super().__init__(block_size, module.device)
+#         self.module = module
+    
+#     def blocks(self) -> Iterator[torch.Tensor]:
+#         for param in self.module.parameters():
+#             flat_param = param.view(-1)
+#             for i in range(0, flat_param.numel(), self.block_size):
+#                 yield flat_param[i:i + self.block_size]
     
     def add_(self, other: ImplicitVector) -> None:
         """Add another vector to this parameter vector."""
@@ -55,11 +71,21 @@ class ImplicitParamVector(ImplicitVector):
             for param_block, other_block in zip(self.blocks(), other.blocks()):
                 param_block.sub_(other_block, alpha=mul_factor)
 
+
+
+
 class ImplicitRandomVector(ImplicitVector):
     def __init__(self, seed: int, ref_vector: ImplicitParamVector):
         super().__init__(ref_vector.block_size, ref_vector.device)
         self.seed = seed
         self.ref_vector = ref_vector
+
+
+# class ImplicitRandomVector(ImplicitVector):
+#     def __init__(self, seed: int, ref_vector: ImplicitParamVector):
+#         super().__init__(ref_vector.block_size, ref_vector.device)
+#         self.seed = seed
+#         self.ref_vector = ref_vector
     
     def __mul__(self, scalar: float) -> 'ImplicitRandomVector':
         """Lazy scalar multiplication."""
@@ -74,15 +100,32 @@ class ImplicitRandomVector(ImplicitVector):
     def __neg__(self) -> 'ImplicitRandomVector':
         return self.__mul__(-1)
     
+    # def blocks(self) -> Iterator[torch.Tensor]:
+    #     generator = torch.Generator(device=self.device)
+    #     generator.manual_seed(self.seed)
+    #     for param in self.ref_vector.module.parameters():
+    #         flat_param = param.view(-1)
+    #         for i in range(0, flat_param.numel(), self.block_size):
+    #             block_size = min(self.block_size, flat_param.numel() - i)
+    #             random_block = torch.randn(block_size, generator=generator, 
+    #                                      device=self.device, dtype=param.dtype)
+    #             yield random_block
+
     def blocks(self) -> Iterator[torch.Tensor]:
+        # print(f"[filter={self.ref_vector.filter_str}] using param: {name}")
+
         generator = torch.Generator(device=self.device)
         generator.manual_seed(self.seed)
-        for param in self.ref_vector.module.parameters():
+        for name, param in self.ref_vector.module.named_parameters():
+            if self.ref_vector.filter_str is not None and self.ref_vector.filter_str not in name:
+                continue
+            # print(f"[filter={self.ref_vector.filter_str}] using param: {name}")  # <-- Moved inside
+
             flat_param = param.view(-1)
             for i in range(0, flat_param.numel(), self.block_size):
                 block_size = min(self.block_size, flat_param.numel() - i)
-                random_block = torch.randn(block_size, generator=generator, 
-                                         device=self.device, dtype=param.dtype)
+                random_block = torch.randn(block_size, generator=generator,
+                                    device=self.device, dtype=param.dtype)
                 yield random_block
 
     @cached_property

--- a/src/tyche/volume.py
+++ b/src/tyche/volume.py
@@ -108,6 +108,8 @@ class VolumeResult:
     mults: torch.Tensor
     deltas: torch.Tensor
     gaussint: torch.Tensor
+    logits_original: torch.Tensor = None
+    logits_perturbed: torch.Tensor = None 
 
 def get_estimates_vectorized_gauss(n, 
                                    sigma,

--- a/src/tyche/volume.py
+++ b/src/tyche/volume.py
@@ -108,8 +108,8 @@ class VolumeResult:
     mults: torch.Tensor
     deltas: torch.Tensor
     gaussint: torch.Tensor
-    logits_original: torch.Tensor = None
-    logits_perturbed: torch.Tensor = None 
+    # logits_original: torch.Tensor = None
+    # logits_perturbed: torch.Tensor = None 
 
 def get_estimates_vectorized_gauss(n, 
                                    sigma,
@@ -169,6 +169,26 @@ def get_estimates_vectorized_gauss(n,
             assert not implicit, "preconditioner only supported for concrete vectors"
             vecs = preconditioner(vecs)
 
+        
+        # perturbation_mask = kwargs.get("perturbation_mask", None)
+        # if perturbation_mask is not None:
+        #     if isinstance(vecs, list):
+        #         # Create a new implicit vector that applies the mask
+        #         from .vectors import ImplicitMaskedRandomVector
+        #         vecs = [ImplicitMaskedRandomVector(vecs[0], perturbation_mask)]
+
+        #     else:
+
+        #         # store the perturbation mask as an implicit vector? 
+        #         # move everything to cpu then multiply??/
+
+        #         # Handle explicit vectors case - apply mask directly
+        #         if isinstance(perturbation_mask, list):
+        #             perturbation_mask = torch.tensor(perturbation_mask, dtype=vecs.dtype, device=vecs.device)
+        #         else:
+        #             perturbation_mask = perturbation_mask.to(dtype=vecs.dtype, device=vecs.device)
+        #         vecs = vecs * perturbation_mask.unsqueeze(0)
+
         if implicit:
             props = norm(vecs[0]).unsqueeze(0)
         else:
@@ -178,6 +198,14 @@ def get_estimates_vectorized_gauss(n,
 
         kwargs = {'cutoff': 1e-3, 'fn': fn, 'iters': 100, 'rtol': rtol, 'init_mult': init_mult, **kwargs}
         mults, deltas = find_radius_vectorized(center, vecs, **kwargs)
+
+
+        # Create a copy of kwargs without 'perturbation_mask'
+        # find_radius_kwargs = {k: v for k, v in kwargs.items() if k != 'perturbation_mask'}
+        # find_radius_kwargs.update({'cutoff': 1e-3, 'fn': fn, 'iters': 100, 'rtol': rtol, 'init_mult': init_mult})
+
+        # Use find_radius_kwargs instead of kwargs
+        # mults, deltas = find_radius_vectorized(center, vecs, **find_radius_kwargs)
 
         x1 = mults * props
         a = 1 / sigma**2


### PR DESCRIPTION
Saving internals during perturbation:
1. mults — perturbation multipliers
2. deltas — parameter changes
3. props — possibly KL divergence or other proportional metrics

Support for layer-specific perturbations:
1.  added logic to restrict perturbation to e.g. layer 15, using a layer mask or filter string when computing implicit vectors.

